### PR TITLE
feat: add hashed auth server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # KP-generator
+
+## Authentication
+
+This version uses a minimal authentication server with hashed passwords.
+
+### Start the server
+
+```bash
+node server.js
+```
+
+The server verifies credentials using Node's `crypto.scrypt` hashing and responds with a session token and public user data.
+
+### Run the client
+
+Open `index.html` in your browser and log in with one of the demo accounts:
+
+- **admin / admin123**
+- **manager / manager123**
+
+Only non-sensitive session data (token and user profile) is stored in `sessionStorage`. Passwords are never saved on the client.
+
+Use the logout button to clear the session data.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kp-generator",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,47 @@
+const http = require('http');
+const crypto = require('crypto');
+
+function hashPassword(password) {
+  return crypto.scryptSync(password, 'salt', 64).toString('hex');
+}
+
+function verifyPassword(password, hash) {
+  const hashed = crypto.scryptSync(password, 'salt', 64).toString('hex');
+  return crypto.timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(hashed, 'hex'));
+}
+
+const users = [
+  { id: 1, username: 'admin', name: 'Администратор Системы', role: 'admin', passwordHash: hashPassword('admin123') },
+  { id: 2, username: 'manager', name: 'Менеджер Продаж', role: 'user', passwordHash: hashPassword('manager123') }
+];
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/api/login') {
+    let body = '';
+    req.on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      try {
+        const { username, password } = JSON.parse(body || '{}');
+        const user = users.find(u => u.username === username);
+        if (!user || !verifyPassword(password, user.passwordHash)) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ message: 'Invalid credentials' }));
+          return;
+        }
+        const sessionUser = { id: user.id, username: user.username, name: user.name, role: user.role };
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ token: crypto.randomUUID(), user: sessionUser }));
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: 'Bad request' }));
+      }
+    });
+  } else {
+    res.writeHead(404, { 'Content-Type': 'text/plain' });
+    res.end('Not found');
+  }
+});
+
+server.listen(3000, () => {
+  console.log('Auth server running on http://localhost:3000');
+});


### PR DESCRIPTION
## Summary
- remove client-side user seeding
- add simple auth server using crypto.scrypt hashing
- switch login to call API and store session token only

## Testing
- `npm test` (fails: no test specified)
- `node server.js &` then `curl -s -X POST -H 'Content-Type: application/json' -d '{"username":"admin","password":"admin123"}' http://localhost:3000/api/login`


------
https://chatgpt.com/codex/tasks/task_e_689c2d4ddbd4832185152e87b14c8e8f