### PR TITLE
Add safe parsing for proposals storage

### DIFF
--- a/app.js
+++ b/app.js
@@ -360,6 +360,18 @@ class ProposalApp {
         }
     }
 
+    safeParse(key, defaultValue) {
+        try {
+            const item = localStorage.getItem(key);
+            return item ? JSON.parse(item) : defaultValue;
+        } catch (error) {
+            console.error(`Error parsing ${key}:`, error);
+            localStorage.setItem(key, JSON.stringify(defaultValue));
+            alert('Произошла ошибка при загрузке данных. Хранилище было сброшено.');
+            return defaultValue;
+        }
+    }
+
     showLoginScreen() {
         const loginScreen = document.getElementById('loginScreen');
         const mainApp = document.getElementById('mainApp');
@@ -466,7 +478,7 @@ class ProposalApp {
     loadAdminPanel() {
         if (this.currentUser.role !== 'admin') return;
         
-        const allProposals = JSON.parse(localStorage.getItem('proposals')) || [];
+        const allProposals = this.safeParse('proposals', []);
         const adminTotalEl = document.getElementById('adminTotalProposals');
         const adminMonthlyEl = document.getElementById('adminMonthlyProposals');
         
@@ -485,7 +497,7 @@ class ProposalApp {
     }
 
     getUserProposals() {
-        const allProposals = JSON.parse(localStorage.getItem('proposals')) || [];
+        const allProposals = this.safeParse('proposals', []);
         if (this.currentUser.role === 'admin') {
             return allProposals;
         }
@@ -706,7 +718,7 @@ class ProposalApp {
         };
         
         // Save to localStorage
-        const proposals = JSON.parse(localStorage.getItem('proposals')) || [];
+        const proposals = this.safeParse('proposals', []);
         
         if (this.editingProposalId) {
             const index = proposals.findIndex(p => p.id === this.editingProposalId);
@@ -724,7 +736,7 @@ class ProposalApp {
     }
 
     getProposalById(id) {
-        const proposals = JSON.parse(localStorage.getItem('proposals')) || [];
+        const proposals = this.safeParse('proposals', []);
         return proposals.find(p => p.id === id);
     }
 
@@ -853,7 +865,7 @@ class ProposalApp {
             return;
         }
         
-        const proposals = JSON.parse(localStorage.getItem('proposals')) || [];
+        const proposals = this.safeParse('proposals', []);
         const filteredProposals = proposals.filter(p => p.id !== id);
         localStorage.setItem('proposals', JSON.stringify(filteredProposals));
         


### PR DESCRIPTION
## Summary
- centralize localStorage JSON parsing in new safeParse helper
- use safeParse in all proposal retrieval methods to reset corrupt data and alert user

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_689c2d53db548321b1ade9d76956260c